### PR TITLE
Update zepto-mvalidate.js

### DIFF
--- a/src/js/zepto-mvalidate.js
+++ b/src/js/zepto-mvalidate.js
@@ -107,7 +107,7 @@
 		 * 只有那些类似type=text的文本框我们才能通过正则表达式去验证pattern,
 		 * 而对于select,radio,checkbox pattern显然是无效的
 		 */
-		if($field.is(type[0])) {
+		if($field.is(type[0]) && status.required) {
 			//如果不匹配
 			if(!fieldPattern.test(fieldValue)){
 				if(fieldRequired){
@@ -121,7 +121,7 @@
 		}
 
 		//如果是data-conditional="name"函数验证,函数返回true或者是false
-		if(fieldConditional !="undefined"){
+		if(fieldConditional !="undefined" && status.pattern){
 			if($.isFunction(fieldConditional)){
 				status.conditional=!!fieldConditional.call($field, fieldValue,options);
 			}else{


### PR DESCRIPTION
验证需要优先级，比如require验证与正则验证同时存在是，require验证没有通过，那么正则验证不需要执行，如果require通过了，才去执行正则验证，conditional验证同理。我遇到的场景是，require与正则与conditional三者同时出现，结果require通过了，正则没有通过，conditional也去执行了。这是不合理的，因为只要其中一个没有通过，当前元素剩下的验证其实也是不需要执行的。比如我在conditional里面添加了ajax远程验证，然而，之前的正则没有通过结果还是执行了ajax远程验证。
