### PR TITLE
修复一些小问题

### DIFF
--- a/src/js/zepto-mvalidate.js
+++ b/src/js/zepto-mvalidate.js
@@ -2,7 +2,7 @@
 	if (typeof define === 'function' && define.amd ) {
 		define(['Zepto'], function(zepto){
 			// 返回构造函数
-			factory(zepto); // 初始化插件	
+			factory(zepto); // 初始化插件
 		});
 	}else if(typeof define === 'function' && define.cmd){
 		define(['Zepto'], function(require,exports,moudles){
@@ -45,7 +45,7 @@
 						},1500)
 					}
 				}
-		   
+
 			return {
 				show:show
 			}
@@ -58,9 +58,9 @@
 				pattern:true
 			},
 			log,//验证提示信息存储变量
-			
+
 			errorTipFormat=$.fn.mvalidate.errorTipFormat,//错误信息输出的格式化
-			
+
 			fieldValue =$.trim($field.val()) || "",
 
 		    //*****获取当前字段的data-validate
@@ -131,17 +131,17 @@
 			}
 		}
 
-     
+
 		//验证通过的信息所在对象
-		
+
 		log = errorTipFormat(fieldDescription.valid);
 		if(!status.required) {
 			log = errorTipFormat(fieldDescription.required);
-			
+
 		}else if(!status.pattern) {
 			log = errorTipFormat(fieldDescription.pattern);
-			
-			
+
+
 		} else if(!status.conditional) {
 			log =errorTipFormat(fieldDescription.conditional);
 		}
@@ -152,7 +152,7 @@
 			//如果是change 或者是keyup 同时是第一次输入的时候就不要验证
 			if((event.type=="keyup" || event.type=="change") && (!$describedShowElem.children().length || !$.trim($describedShowElem.text()))){
 
-			}else{					
+			}else{
 				$describedShowElem.html(log || '');
 				fieldValidTypeHand($field,status,options)
 			}
@@ -161,10 +161,11 @@
 		if(typeof(validation.each) == 'function') {
 			validation.each.call($field, event, status, options);
 		}
-		options.eachField.call($field, event, status, options);
 
-		if(status.required && status.pattern && status.conditional) {	
-			
+		typeof(options.eachField) === 'function' && options.eachField.call($field, event, status, options);
+
+		if(status.required && status.pattern && status.conditional) {
+
 			if(typeof(validation.valid) == 'function') {//二外拓展的
 				validation.valid.call($field, event, status, options);
 			}
@@ -180,9 +181,9 @@
 			if(typeof(validation.invalid) == 'function') {
 				validation.invalid.call($field, event, status, options);
 			}
-			options.eachInvalidField.call($field, event, status, options);	
+			typeof(options.eachInvalidField) === 'function' && options.eachInvalidField.call($field, event, status, options);
 		}
-		
+
 	/**
 	 * 如果是data-describedby="elemId"验证信息要显示的地方，类型3的验证:
 		 * 		第一元素获取焦点，keyUp的时候要一直验证，如果正确那么错误信息就隐藏，如果不正确，那么错误
@@ -193,12 +194,12 @@
 	};
 	$.extend($,{
 		mvalidateExtend:function(options){
-			return $.extend(extend, options);	
+			return $.extend(extend, options);
 		}
 	});
 
-	
-	
+
+
 	$.fn.mvalidate=function(options){
 		var defaults={
 			type:1,
@@ -224,14 +225,14 @@
 		opts.firstInvalid=false;
 		flag=opts.type==1 ? false : true;
 		return this.mvalidateDestroy().each(function(event) {
-			
+
 			var $form=$(this),
 				$fields;//存放当前表单下的所有元素;
 			if(!$form.is("form")) return;
 			opts.$form=$form;
 			$form.data(name,{"options":opts});
 			$fields=$form.find(allTypes);
-			
+
 			//
 			if(flag && opts.onKeyup){
 				$fields.filter(type[0]).each(function() {
@@ -249,7 +250,7 @@
 						$(this).on('change.' + namespace, function(event) {
 							validateField.call(this, event, opts);
 						})
-					}	
+					}
 				})
 			}
 
@@ -264,7 +265,7 @@
 							formValid = false;
 						}
 					});
-					
+
 					if(formValid){
 						if(!opts.sendForm){
 							event.preventDefault();
@@ -272,7 +273,7 @@
 						if($.isFunction(opts.valid)){
 							opts.valid.call($form,event,opts);
 						}
-					//验证没有通过,禁用提交事件,以及绑定在这个elem上的其他事件	
+					//验证没有通过,禁用提交事件,以及绑定在这个elem上的其他事件
 					}else{
 						event.preventDefault();
 						event.stopImmediatePropagation();
@@ -280,7 +281,7 @@
 							opts.invalid.call($form,event,opts)
 						}
 					}
-					
+
 				})
 			}
 		})
@@ -291,7 +292,7 @@
 		if($form.is('form') && $.isPlainObject(dataValidate) && typeof(dataValidate.options.namespace) == 'string') {
 			$fields = $form.removeData(name).find(allTypes);
 			$fields.off('.' + dataValidate.options.namespace);
-		}	
+		}
 		return $form;
 	};
 	$.fn.mvalidate.errorTipFormat=function(text){


### PR DESCRIPTION
非常不错的插件,用上很顺手.今天用的时候遇到一些其他没有过的问题.在用zepto-mvalidate.js时
以下这句代码会出现错误,大概位置在164行左右.
```
options.eachField.call($field, event, status, options);
```
因为我用的是比较低版本的zepto,所以找不到$.noop这个函数.就导致了脚本中断报错,从而没有将表单的默认提交事件给阻止掉.以下是我修复过后的
```
typeof(options.eachField) === 'function' && options.eachField.call($field, event, status, options);
```
同理.有几个地方都有这样的问题.例如,
```
options.eachInvalidField.call($field, event, status, options);   // 184行左右
```
thanks